### PR TITLE
Added server start invocation in main function example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ import "github.com/arouam/pastis"
                 "hello": "world",
             })
         })
+        pastis.Start(r)
     }
 ```
 ## Path parameters:


### PR DESCRIPTION
This commit adds the invocation of the pastis.Start(r) function in the main function example within the documentation. The Start function is a crucial part of the Pastis framework as it triggers the AWS Lambda function to start running the server.